### PR TITLE
feat(calendar): add optional Google Meet conference to create_calendar_event

### DIFF
--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/calendar.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/calendar.py
@@ -3,6 +3,7 @@ Google Calendar service implementation.
 """
 
 import logging
+import uuid
 from datetime import datetime
 from typing import Any
 
@@ -137,6 +138,7 @@ class CalendarService(BaseGoogleService):
         send_notifications: bool = True,
         timezone: str | None = None,
         calendar_id: str = "primary",
+        add_meet: bool = False,
     ) -> dict[str, Any] | None:
         """
         Create a new calendar event.
@@ -151,6 +153,7 @@ class CalendarService(BaseGoogleService):
             send_notifications: Whether to send notifications to attendees
             timezone: Timezone for the event (e.g. 'America/New_York')
             calendar_id: ID of the calendar to create the event in
+            add_meet: Attach a Google Meet conference to the event (default False)
 
         Returns:
             Created event data or None if creation fails
@@ -177,6 +180,19 @@ class CalendarService(BaseGoogleService):
             if attendees:
                 event["attendees"] = [{"email": email} for email in attendees]
 
+            # Attach a Google Meet conference when requested. Creating one
+            # requires a createRequest with a unique requestId plus
+            # conferenceDataVersion=1 on the insert call.
+            insert_kwargs: dict[str, Any] = {}
+            if add_meet:
+                event["conferenceData"] = {
+                    "createRequest": {
+                        "requestId": uuid.uuid4().hex,
+                        "conferenceSolutionKey": {"type": "hangoutsMeet"},
+                    }
+                }
+                insert_kwargs["conferenceDataVersion"] = 1
+
             # Map boolean to required string for sendUpdates
             send_updates_value = "all" if send_notifications else "none"
 
@@ -187,6 +203,7 @@ class CalendarService(BaseGoogleService):
                     calendarId=calendar_id,
                     body=event,
                     sendUpdates=send_updates_value,
+                    **insert_kwargs,
                 )
                 .execute()
             )

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/tools/calendar.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/tools/calendar.py
@@ -140,6 +140,7 @@ async def create_calendar_event(
     attendees: list[str] | None = None,
     send_notifications: bool = True,
     timezone: str | None = None,
+    add_meet: bool = False,
 ) -> dict[str, Any]:
     """
     Create a new calendar event.
@@ -154,6 +155,7 @@ async def create_calendar_event(
         attendees: List of attendee email addresses (optional).
         send_notifications: Whether to send notifications to attendees (default True).
         timezone: Timezone for the event (e.g., 'America/New_York', defaults to UTC).
+        add_meet: Attach a Google Meet conference to the event (default False).
 
     Returns:
         A dictionary containing the created event details.
@@ -173,6 +175,7 @@ async def create_calendar_event(
         send_notifications=send_notifications,
         timezone=timezone,
         calendar_id=calendar_id,
+        add_meet=add_meet,
     )
 
     if not result or (isinstance(result, dict) and result.get("error")):

--- a/tests/google-workspace-mcp/unit/services/calendar/test_create_event.py
+++ b/tests/google-workspace-mcp/unit/services/calendar/test_create_event.py
@@ -141,3 +141,54 @@ class TestCalendarCreateEvent:
         # Verify error handling
         mock_calendar_service.handle_api_error.assert_called_once_with("create_event", http_error)
         assert result == expected_error
+
+    def test_create_event_with_meet(self, mock_calendar_service):
+        """Test that add_meet=True requests a Google Meet conference."""
+        summary = "Meeting with Meet"
+        start_time = "2023-01-01T10:00:00Z"
+        end_time = "2023-01-01T11:00:00Z"
+
+        mock_created_event = {
+            "id": "event123",
+            "summary": summary,
+            "conferenceData": {"entryPoints": [{"uri": "https://meet.google.com/abc-defg-hij"}]},
+        }
+        mock_execute = MagicMock(return_value=mock_created_event)
+        mock_calendar_service._service.events.return_value.insert.return_value.execute = mock_execute
+
+        result = mock_calendar_service.create_event(
+            summary=summary,
+            start_time=start_time,
+            end_time=end_time,
+            add_meet=True,
+        )
+
+        mock_calendar_service._service.events.return_value.insert.assert_called_once()
+        call_args = mock_calendar_service._service.events.return_value.insert.call_args
+        body_arg = call_args[1]["body"]
+
+        # A Meet conference is requested via conferenceData.createRequest ...
+        create_request = body_arg["conferenceData"]["createRequest"]
+        assert create_request["conferenceSolutionKey"]["type"] == "hangoutsMeet"
+        assert create_request["requestId"]  # non-empty unique request id
+        # ... and conferenceDataVersion=1 is required for the link to be generated.
+        assert call_args[1]["conferenceDataVersion"] == 1
+
+        assert result == mock_created_event
+
+    def test_create_event_no_meet_by_default(self, mock_calendar_service):
+        """Test that no Meet conference is attached unless add_meet is set."""
+        mock_created_event = {"id": "event123", "summary": "No Meet"}
+        mock_execute = MagicMock(return_value=mock_created_event)
+        mock_calendar_service._service.events.return_value.insert.return_value.execute = mock_execute
+
+        mock_calendar_service.create_event(
+            summary="No Meet",
+            start_time="2023-01-01T10:00:00Z",
+            end_time="2023-01-01T11:00:00Z",
+        )
+
+        call_args = mock_calendar_service._service.events.return_value.insert.call_args
+        body_arg = call_args[1]["body"]
+        assert "conferenceData" not in body_arg
+        assert "conferenceDataVersion" not in call_args[1]


### PR DESCRIPTION
## What

Adds an optional `add_meet` parameter (default `False`) to the `create_calendar_event` tool and the underlying `CalendarService.create_event`. When `add_meet=True`, the created event gets a Google Meet conference attached.

## Why

`create_calendar_event` currently has no way to attach a Google Meet conference, so events created through the MCP never get a Meet link — even though the read path already surfaces `conferenceData`/`hangoutLink`. This adds the create-side capability.

## How

Google Calendar requires two things to provision a Meet link on insert:

- a `conferenceData.createRequest` with a unique `requestId` and `conferenceSolutionKey.type = "hangoutsMeet"`, and
- `conferenceDataVersion=1` passed to `events().insert()`.

Both are added only when `add_meet=True`.

## Compatibility

Non-breaking: `add_meet` defaults to `False`, so existing callers see no change — callers opt in per event.

## Tests

Adds two unit tests to `tests/google-workspace-mcp/unit/services/calendar/test_create_event.py`:

- `test_create_event_with_meet` — asserts the `conferenceData.createRequest` (hangoutsMeet) and `conferenceDataVersion=1` are sent.
- `test_create_event_no_meet_by_default` — asserts neither is sent by default.

All calendar service unit tests pass locally (`5 passed`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional Google Meet links to events created via `create_calendar_event`. Set `add_meet=True` to attach a Meet conference; defaults to `False` to preserve existing behavior.

- **New Features**
  - Added `add_meet` (default `False`) to `create_calendar_event` and `CalendarService.create_event`.
  - When `add_meet=True`, sends `conferenceData.createRequest` (with unique `requestId` and `conferenceSolutionKey.type="hangoutsMeet"`) and `conferenceDataVersion=1` so Google generates the Meet link.

<sup>Written for commit 080956b33273e9ee755611c8b354d3cc8a8e6036. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Arclio/arclio-mcp-tooling/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

