### PR TITLE
feat(base): parse Google error bodies, semantic error codes, 401/429 retry

### DIFF
--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/base.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/base.py
@@ -148,7 +148,9 @@ class BaseGoogleService:
         """Exponential backoff with jitter, honoring a Retry-After header."""
         retry_after = None
         if error.resp:
-            header = error.resp.get("retry-after") or error.resp.get("Retry-After")
+            # httplib2 lowercases all response header keys, so look up the
+            # lowercase form only.
+            header = error.resp.get("retry-after")
             if header:
                 try:
                     retry_after = float(header)

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/base.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/base.py
@@ -2,15 +2,67 @@
 Base classes and utilities for Google API service implementations.
 """
 
+import json
 import logging
+import random
+import time
 from typing import Any
 
+import google.auth.transport.requests
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
 from google_workspace_mcp.auth import gauth
 
 logger = logging.getLogger(__name__)
+
+# HTTP statuses that are safe to retry with backoff.
+_RETRYABLE_STATUSES = {429, 500, 502, 503, 504}
+_MAX_RETRIES = 3
+_BASE_DELAY_SECONDS = 0.5
+
+# Normalized, agent-facing error codes. Agents can branch on these instead of
+# parsing raw HTTP status codes.
+ERROR_CODE_BY_STATUS = {
+    400: "INVALID_ARGUMENT",
+    401: "AUTH_EXPIRED",
+    403: "PERMISSION_DENIED",
+    404: "NOT_FOUND",
+    409: "CONFLICT",
+    429: "RATE_LIMITED",
+    500: "TRANSIENT",
+    502: "TRANSIENT",
+    503: "TRANSIENT",
+    504: "TRANSIENT",
+}
+
+
+def _parse_google_error(error: HttpError) -> dict[str, Any]:
+    """Pull the human-readable message and reason out of HttpError.content.
+
+    googleapiclient.errors.HttpError does NOT expose error_details; the useful
+    JSON (e.g. "Requested range is out of grid") lives in error.content. This
+    parses it defensively, returning {} when the body isn't the expected shape.
+    """
+    raw = getattr(error, "content", None)
+    if not raw:
+        return {}
+    try:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", errors="replace")
+        payload = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    err = payload.get("error", payload)
+    parsed: dict[str, Any] = {}
+    if isinstance(err, dict):
+        if err.get("message"):
+            parsed["api_message"] = err["message"]
+        if err.get("status"):
+            parsed["api_status"] = err["status"]
+        if err.get("errors"):
+            parsed["api_errors"] = err["errors"]
+    return parsed
 
 
 class BaseGoogleService:
@@ -33,6 +85,79 @@ class BaseGoogleService:
             self._service = build(self.service_name, self.version, credentials=credentials)
         return self._service
 
+    def execute_with_retry(self, request: Any, operation: str = "execute") -> Any:
+        """Execute a googleapiclient request with backoff and a 401 refresh-retry.
+
+        Wrap a request object (the thing you would call ``.execute()`` on) so the
+        call survives transient failures instead of dead-ending:
+
+        - 429 / 5xx → exponential backoff with jitter, honoring ``Retry-After``,
+          up to ``_MAX_RETRIES`` attempts.
+        - 401 → refresh the credentials once and retry, since google-auth's
+          in-transport refresh can still leave a stale token on the built client.
+
+        Returns the request's result on success. Re-raises the final HttpError on
+        exhaustion so callers keep routing it through ``handle_api_error``.
+        """
+        attempt = 0
+        refreshed = False
+        while True:
+            try:
+                return request.execute()
+            except HttpError as error:
+                status = error.resp.status if error.resp else None
+
+                # One-shot credential refresh on 401.
+                if status == 401 and not refreshed:
+                    refreshed = True
+                    if self._try_refresh_credentials():
+                        logger.info(
+                            f"Refreshed credentials after 401 in {operation}; retrying."
+                        )
+                        continue
+
+                # Backoff on transient statuses.
+                if status in _RETRYABLE_STATUSES and attempt < _MAX_RETRIES:
+                    delay = self._backoff_delay(attempt, error)
+                    logger.warning(
+                        f"{operation} got {status}; retry {attempt + 1}/{_MAX_RETRIES} "
+                        f"in {delay:.2f}s."
+                    )
+                    time.sleep(delay)
+                    attempt += 1
+                    continue
+
+                raise
+
+    def _try_refresh_credentials(self) -> bool:
+        """Force a credential refresh and rebuild the client. Returns success."""
+        try:
+            credentials = gauth.get_credentials()
+            credentials.refresh(google.auth.transport.requests.Request())
+            # Rebuild the client so it picks up the new token.
+            self._service = build(
+                self.service_name, self.version, credentials=credentials
+            )
+            return True
+        except Exception:
+            logger.exception("Credential refresh failed")
+            return False
+
+    @staticmethod
+    def _backoff_delay(attempt: int, error: HttpError) -> float:
+        """Exponential backoff with jitter, honoring a Retry-After header."""
+        retry_after = None
+        if error.resp:
+            header = error.resp.get("retry-after") or error.resp.get("Retry-After")
+            if header:
+                try:
+                    retry_after = float(header)
+                except (ValueError, TypeError):
+                    retry_after = None
+        if retry_after is not None:
+            return retry_after
+        return _BASE_DELAY_SECONDS * (2**attempt) + random.uniform(0, 0.25)
+
     def handle_api_error(self, operation: str, error: Exception) -> dict[str, Any]:
         """
         Standardized error handling for Google API operations.
@@ -42,23 +167,36 @@ class BaseGoogleService:
             error (Exception): The exception that occurred.
 
         Returns:
-            Dict[str, Any]: Structured error information.
+            Dict[str, Any]: Structured error information with a normalized
+            ``error_code`` and Google's real error message when available.
         """
         if isinstance(error, HttpError):
-            # Extract meaningful error information from Google API errors
-            error_details = {
+            status = error.resp.status if error.resp else None
+            error_details: dict[str, Any] = {
                 "error": True,
                 "operation": operation,
-                "status_code": error.resp.status,
-                "reason": error.resp.reason,
+                "status_code": status,
+                "reason": error.resp.reason if error.resp else None,
                 "message": str(error),
+                "error_code": ERROR_CODE_BY_STATUS.get(status, "API_ERROR"),
             }
 
-            # Try to extract additional error details from the response
-            if hasattr(error, "error_details"):
-                error_details["details"] = error.error_details
+            # Surface Google's real error body (message/status/sub-errors).
+            parsed = _parse_google_error(error)
+            if parsed:
+                error_details.update(parsed)
+                # Prefer the API's human message as the headline when present.
+                if parsed.get("api_message"):
+                    error_details["message"] = parsed["api_message"]
 
-            logger.error(f"Google API error in {operation}: {error.resp.status} {error.resp.reason} - {error}")
+            if status == 429:
+                delay = self._backoff_delay(0, error)
+                error_details["retry_after"] = round(delay, 2)
+
+            logger.error(
+                f"Google API error in {operation}: {status} "
+                f"{error_details.get('reason')} - {error_details['message']}"
+            )
 
         else:
             # Handle non-HTTP errors
@@ -66,6 +204,7 @@ class BaseGoogleService:
                 "error": True,
                 "operation": operation,
                 "message": str(error),
+                "error_code": "INTERNAL_ERROR",
                 "type": type(error).__name__,
             }
             logger.error(f"Unexpected error in {operation}: {type(error).__name__} - {error}")

--- a/tests/google-workspace-mcp/unit/services/base/test_error_handling.py
+++ b/tests/google-workspace-mcp/unit/services/base/test_error_handling.py
@@ -1,0 +1,108 @@
+"""
+Unit tests for BaseGoogleService error handling and retry behavior.
+
+Covers the three highest-leverage fixes: parsing Google's real error body,
+normalized semantic error codes, 401 refresh-retry, and 429/5xx backoff.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google_workspace_mcp.services.base import BaseGoogleService
+from googleapiclient.errors import HttpError
+
+
+def _http_error(status: int, content: bytes = b"", reason: str = "Error", headers=None):
+    resp = MagicMock()
+    resp.status = status
+    resp.reason = reason
+    resp.get.side_effect = (headers or {}).get
+    return HttpError(resp=resp, content=content)
+
+
+@pytest.fixture
+def service():
+    return BaseGoogleService(service_name="sheets", version="v4")
+
+
+class TestHandleApiError:
+    def test_parses_google_error_body_as_message(self, service):
+        content = b'{"error": {"code": 400, "message": "Requested range is out of grid", "status": "INVALID_ARGUMENT"}}'
+        result = service.handle_api_error("read_range", _http_error(400, content))
+        assert result["error"] is True
+        assert result["message"] == "Requested range is out of grid"
+        assert result["api_status"] == "INVALID_ARGUMENT"
+        assert result["error_code"] == "INVALID_ARGUMENT"
+
+    def test_semantic_code_for_known_statuses(self, service):
+        assert service.handle_api_error("x", _http_error(401))["error_code"] == "AUTH_EXPIRED"
+        assert service.handle_api_error("x", _http_error(403))["error_code"] == "PERMISSION_DENIED"
+        assert service.handle_api_error("x", _http_error(404))["error_code"] == "NOT_FOUND"
+        assert service.handle_api_error("x", _http_error(429))["error_code"] == "RATE_LIMITED"
+        assert service.handle_api_error("x", _http_error(503))["error_code"] == "TRANSIENT"
+
+    def test_429_includes_retry_after(self, service):
+        result = service.handle_api_error(
+            "x", _http_error(429, headers={"retry-after": "7"})
+        )
+        assert result["retry_after"] == 7.0
+
+    def test_malformed_body_does_not_crash(self, service):
+        result = service.handle_api_error("x", _http_error(500, b"not json"))
+        assert result["error"] is True
+        assert result["error_code"] == "TRANSIENT"
+
+    def test_non_http_error(self, service):
+        result = service.handle_api_error("x", ValueError("boom"))
+        assert result["error_code"] == "INTERNAL_ERROR"
+        assert result["type"] == "ValueError"
+
+
+class TestExecuteWithRetry:
+    def test_returns_result_on_success(self, service):
+        request = MagicMock()
+        request.execute.return_value = {"ok": True}
+        assert service.execute_with_retry(request) == {"ok": True}
+        assert request.execute.call_count == 1
+
+    def test_retries_on_429_then_succeeds(self, service):
+        request = MagicMock()
+        request.execute.side_effect = [
+            _http_error(429, headers={"retry-after": "0"}),
+            {"ok": True},
+        ]
+        with patch("time.sleep"):  # don't actually wait
+            result = service.execute_with_retry(request, "op")
+        assert result == {"ok": True}
+        assert request.execute.call_count == 2
+
+    def test_gives_up_after_max_retries(self, service):
+        request = MagicMock()
+        request.execute.side_effect = _http_error(503)
+        with patch("time.sleep"):
+            with pytest.raises(HttpError):
+                service.execute_with_retry(request, "op")
+        # initial try + 3 retries
+        assert request.execute.call_count == 4
+
+    def test_401_triggers_one_refresh_then_retry(self, service):
+        request = MagicMock()
+        request.execute.side_effect = [_http_error(401), {"ok": True}]
+        with patch.object(service, "_try_refresh_credentials", return_value=True) as refresh:
+            result = service.execute_with_retry(request, "op")
+        assert result == {"ok": True}
+        refresh.assert_called_once()
+
+    def test_401_not_retried_when_refresh_fails(self, service):
+        request = MagicMock()
+        request.execute.side_effect = _http_error(401)
+        with patch.object(service, "_try_refresh_credentials", return_value=False):
+            with pytest.raises(HttpError):
+                service.execute_with_retry(request, "op")
+
+    def test_non_retryable_4xx_raises_immediately(self, service):
+        request = MagicMock()
+        request.execute.side_effect = _http_error(404)
+        with pytest.raises(HttpError):
+            service.execute_with_retry(request, "op")
+        assert request.execute.call_count == 1


### PR DESCRIPTION
The highest-leverage fix — every tool routes errors through the base service, so all 47 tools benefit.

## What changed
- `handle_api_error` checked `error_details` (which `HttpError` lacks), so Google's real message in `error.content` was dropped — agents got bare "400 Bad Request". Now parses `error.content` for the real message/status/sub-errors and surfaces it as the headline.
- Adds a normalized `error_code` (`AUTH_EXPIRED` / `RATE_LIMITED` / `NOT_FOUND` / `PERMISSION_DENIED` / `TRANSIENT` / ...) so agents branch on a code instead of raw HTTP status. Attaches `retry_after` on 429.
- New `execute_with_retry()` wraps a request with exponential backoff + jitter (honoring `Retry-After`) on 429/5xx, and a one-shot credential refresh on 401.

## Scope note
`handle_api_error` improvements apply to all existing call sites immediately. `execute_with_retry` is opt-in; this PR does not yet wire it into every `.execute()` site (a separate mechanical pass). It is exercised by the Sheets batchUpdate path in the drive/sheets PR.

## Tests
11 new base-service tests (error-body parsing, semantic codes, 401-refresh, 429/5xx backoff, Retry-After).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves base Google API error handling so agents see real messages and stable error codes, and adds a retry helper with backoff and 401 refresh to reduce flaky failures. Error parsing applies everywhere; retry is opt-in for now.

- New Features
  - Added `execute_with_retry()` to retry 429/5xx with exponential backoff + jitter (honors `Retry-After`) and refresh credentials once on 401; re-raises final errors for `handle_api_error`. Currently used in the Sheets batchUpdate path.
  - Introduced normalized `error_code` values (e.g., `AUTH_EXPIRED`, `RATE_LIMITED`, `NOT_FOUND`, `PERMISSION_DENIED`, `TRANSIENT`) and include `retry_after` on 429.

- Bug Fixes
  - `handle_api_error` now parses `HttpError.content` to surface Google’s real message/status/sub-errors, replacing generic “400 Bad Request.” Applies to all existing call sites.
  - Fixed `retry-after` header handling in backoff logic (`httplib2` lowercases header keys).

<sup>Written for commit 7823659213a18861ad2709aa4209c9963f0efbe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Arclio/arclio-mcp-tooling/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

