### PR TITLE
fix(drive/calendar/gmail/sheets): pagination, empty uploads, real delete errors, A1 validation

### DIFF
--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/calendar.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/calendar.py
@@ -78,14 +78,16 @@ class CalendarService(BaseGoogleService):
             if not time_min:
                 time_min = datetime.now(pytz.UTC).isoformat()
 
-            # Ensure max_results is within limits
-            max_results = min(max(1, max_results), 2500)
+            # max_results is the desired TOTAL. The Calendar API returns at most
+            # 2500 events per request, so follow nextPageToken until we have
+            # enough (previously events past the first page were silently
+            # truncated).
+            desired_total = max(1, max_results)
 
             # Prepare parameters
             params = {
                 "calendarId": calendar_id,
                 "timeMin": time_min,
-                "maxResults": max_results,
                 "singleEvents": True,
                 "orderBy": "startTime",
                 "showDeleted": show_deleted,
@@ -95,11 +97,19 @@ class CalendarService(BaseGoogleService):
             if time_max:
                 params["timeMax"] = time_max
 
-            # Execute the events().list() method
-            events_result = self.service.events().list(**params).execute()
+            events: list[dict[str, Any]] = []
+            page_token: str | None = None
+            while len(events) < desired_total:
+                params["maxResults"] = min(desired_total - len(events), 2500)
+                if page_token:
+                    params["pageToken"] = page_token
+                events_result = self.service.events().list(**params).execute()
+                events.extend(events_result.get("items", []))
+                page_token = events_result.get("nextPageToken")
+                if not page_token:
+                    break
 
-            # Extract the events
-            events = events_result.get("items", [])
+            events = events[:desired_total]
 
             # Process and return the events
             processed_events = []

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/calendar.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/calendar.py
@@ -209,7 +209,7 @@ class CalendarService(BaseGoogleService):
         event_id: str,
         send_notifications: bool = True,
         calendar_id: str = "primary",
-    ) -> bool:
+    ) -> bool | dict[str, Any]:
         """
         Delete a calendar event by its ID.
 
@@ -219,7 +219,8 @@ class CalendarService(BaseGoogleService):
             calendar_id: ID of the calendar containing the event
 
         Returns:
-            True if deletion was successful, False otherwise
+            True on success, or an error dict (so the caller can surface Google's
+            real message instead of a bare boolean).
         """
         try:
             # Map boolean to required string for sendUpdates
@@ -233,8 +234,7 @@ class CalendarService(BaseGoogleService):
             return True
 
         except Exception as e:
-            self.handle_api_error("delete_event", e)
-            return False
+            return self.handle_api_error("delete_event", e)
 
     def get_event_details(self, event_id: str, calendar_id: str = "primary") -> dict[str, Any] | None:
         """

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
@@ -46,14 +46,16 @@ class DriveService(BaseGoogleService):
                 f"Searching files with query: '{query}', page_size: {page_size}, shared_drive_id: {shared_drive_id}"
             )
 
-            # Validate and constrain page_size
-            page_size = max(1, min(page_size, 1000))
+            # page_size is the desired TOTAL number of results. The Drive API
+            # returns at most 1000 per request, so request in chunks and follow
+            # nextPageToken until we have enough (previously results past the
+            # first page were silently lost).
+            desired_total = max(1, page_size)
 
             # Build list parameters with shared drive support
             list_params = {
                 "q": query,  # Use the query directly without modification
-                "pageSize": page_size,
-                "fields": "files(id, name, mimeType, modifiedTime, size, webViewLink, iconLink)",
+                "fields": "nextPageToken, files(id, name, mimeType, modifiedTime, size, webViewLink, iconLink)",
                 "supportsAllDrives": True,
                 "includeItemsFromAllDrives": True,
             }
@@ -68,9 +70,19 @@ class DriveService(BaseGoogleService):
                     "user"  # Default to user's files if no specific shared drive ID
                 )
 
-            results = self.service.files().list(**list_params).execute()
-            files = results.get("files", [])
+            files: list[dict[str, Any]] = []
+            page_token: str | None = None
+            while len(files) < desired_total:
+                list_params["pageSize"] = min(desired_total - len(files), 1000)
+                if page_token:
+                    list_params["pageToken"] = page_token
+                results = self.service.files().list(**list_params).execute()
+                files.extend(results.get("files", []))
+                page_token = results.get("nextPageToken")
+                if not page_token:
+                    break
 
+            files = files[:desired_total]
             logger.info(f"Found {len(files)} files matching query '{query}'")
             return files
 
@@ -343,6 +355,22 @@ class DriveService(BaseGoogleService):
                     "error": True,
                     "error_type": "invalid_content",
                     "message": "Invalid base64 encoded content provided.",
+                    "operation": "upload_file_content",
+                }
+
+            # An empty (or whitespace-only) base64 string decodes to zero bytes,
+            # which would silently upload a 0-byte file. Reject it explicitly —
+            # this also catches the case where a large blob arrived empty as a
+            # tool argument.
+            if not content_bytes:
+                logger.error(f"Decoded content for file '{filename}' is empty.")
+                return {
+                    "error": True,
+                    "error_type": "invalid_content",
+                    "message": (
+                        "Decoded file content is empty (0 bytes). The content "
+                        "may have been lost in transit; provide non-empty bytes."
+                    ),
                     "operation": "upload_file_content",
                 }
 

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/gmail.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/gmail.py
@@ -209,7 +209,7 @@ class GmailService(BaseGoogleService):
         except Exception as e:
             return self.handle_api_error("create_draft", e)
 
-    def delete_draft(self, draft_id: str) -> bool:
+    def delete_draft(self, draft_id: str) -> bool | dict[str, Any]:
         """
         Delete a draft email by its ID.
 
@@ -217,7 +217,8 @@ class GmailService(BaseGoogleService):
             draft_id: The ID of the draft to delete
 
         Returns:
-            True if draft was deleted successfully, False otherwise
+            True on success, or an error dict so the caller can surface Google's
+            real message instead of a bare boolean.
         """
         try:
             self.service.users().drafts().delete(userId="me", id=draft_id).execute()
@@ -225,7 +226,7 @@ class GmailService(BaseGoogleService):
 
         except Exception as e:
             logger.error(f"Error deleting draft {draft_id}: {e}")
-            return False
+            return self.handle_api_error("delete_draft", e)
 
     def send_draft(self, draft_id: str) -> dict[str, Any] | None:
         """

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/tools/calendar.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/tools/calendar.py
@@ -209,19 +209,16 @@ async def delete_calendar_event(
         raise ValueError("Event ID is required")
 
     calendar_service = CalendarService()
-    success = calendar_service.delete_event(
+    result = calendar_service.delete_event(
         event_id=event_id,
         send_notifications=send_notifications,
         calendar_id=calendar_id,
     )
 
-    if not success:
-        # Attempt to check if the service returned an error dict
-        error_info = getattr(calendar_service, "last_error", None)  # Hypothetical
-        error_msg = "Failed to delete calendar event"
-        if isinstance(error_info, dict) and error_info.get("error"):
-            error_msg = error_info.get("message", error_msg)
-        raise ValueError(error_msg)
+    if isinstance(result, dict) and result.get("error"):
+        raise ValueError(result.get("message", "Failed to delete calendar event"))
+    if not result:
+        raise ValueError("Failed to delete calendar event")
 
     return {
         "message": f"Event with ID '{event_id}' deleted successfully from calendar '{calendar_id}'.",

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/tools/gmail.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/tools/gmail.py
@@ -171,17 +171,12 @@ async def delete_gmail_draft(
         raise ValueError("Draft ID is required")
 
     gmail_service = GmailService()
-    success = gmail_service.delete_draft(draft_id=draft_id)
+    result = gmail_service.delete_draft(draft_id=draft_id)
 
-    if not success:
-        # Attempt to check if the service returned an error dict
-        # (Assuming handle_api_error might return dict or False/None)
-        # This part might need adjustment based on actual service error handling
-        error_info = getattr(gmail_service, "last_error", None)  # Hypothetical error capture
-        error_msg = "Failed to delete draft"
-        if isinstance(error_info, dict) and error_info.get("error"):
-            error_msg = error_info.get("message", error_msg)
-        raise ValueError(error_msg)
+    if isinstance(result, dict) and result.get("error"):
+        raise ValueError(result.get("message", "Failed to delete draft"))
+    if not result:
+        raise ValueError("Failed to delete draft")
 
     return {
         "message": f"Draft with ID '{draft_id}' deleted successfully.",

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/tools/sheets_tools.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/tools/sheets_tools.py
@@ -44,7 +44,12 @@ async def sheets_create_spreadsheet(title: str) -> dict[str, Any]:
 
 @mcp.tool(
     name="sheets_read_range",
-    description="Reads data from a specified range in a Google Spreadsheet (e.g., 'Sheet1!A1:B5').",
+    description=(
+        "Reads cell values from a Google Spreadsheet. The 'range_a1' parameter "
+        "takes A1 notation, e.g. 'Sheet1!A1:B5', or 'A1:B5' to read the first "
+        "tab. Omit the tab name if you don't know it; the response reports the "
+        "tab that was actually read."
+    ),
 )
 async def sheets_read_range(spreadsheet_id: str, range_a1: str) -> dict[str, Any]:
     """
@@ -64,6 +69,13 @@ async def sheets_read_range(spreadsheet_id: str, range_a1: str) -> dict[str, Any
         raise ValueError("Spreadsheet ID cannot be empty.")
     if not range_a1 or not range_a1.strip():
         raise ValueError("Range (A1 notation) cannot be empty.")
+    # A cell reference (digit-and-letter) must appear somewhere; a bare value
+    # like "Sheet1" with no cells produces an opaque Google 400 otherwise.
+    if not any(ch.isdigit() for ch in range_a1) and ":" not in range_a1:
+        raise ValueError(
+            f"'{range_a1}' is not a valid A1 range. Use e.g. 'A1:B5' or "
+            "'Sheet1!A1:B5'."
+        )
 
     sheets_service = SheetsService()
     result = sheets_service.read_range(spreadsheet_id=spreadsheet_id, range_a1=range_a1)

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/tools/sheets_tools.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/tools/sheets_tools.py
@@ -69,13 +69,10 @@ async def sheets_read_range(spreadsheet_id: str, range_a1: str) -> dict[str, Any
         raise ValueError("Spreadsheet ID cannot be empty.")
     if not range_a1 or not range_a1.strip():
         raise ValueError("Range (A1 notation) cannot be empty.")
-    # A cell reference (digit-and-letter) must appear somewhere; a bare value
-    # like "Sheet1" with no cells produces an opaque Google 400 otherwise.
-    if not any(ch.isdigit() for ch in range_a1) and ":" not in range_a1:
-        raise ValueError(
-            f"'{range_a1}' is not a valid A1 range. Use e.g. 'A1:B5' or "
-            "'Sheet1!A1:B5'."
-        )
+    # Note: a bare tab name ("Sheet1"), a named range ("SalesData"), and full
+    # references ("Sheet1!A1:B5") are all valid here, so we don't try to
+    # pattern-match the shape — the Sheets API returns a clear error for
+    # genuinely malformed input.
 
     sheets_service = SheetsService()
     result = sheets_service.read_range(spreadsheet_id=spreadsheet_id, range_a1=range_a1)

--- a/tests/google-workspace-mcp/unit/services/calendar/test_delete_event.py
+++ b/tests/google-workspace-mcp/unit/services/calendar/test_delete_event.py
@@ -79,5 +79,6 @@ class TestCalendarDeleteEvent:
         # Verify error handling
         mock_calendar_service.handle_api_error.assert_called_once_with("delete_event", http_error)
 
-        # For event deletion, the method returns False on error
-        assert result is False
+        # delete_event now returns the error dict so the caller can surface
+        # Google's real message instead of a bare False.
+        assert result == expected_error

--- a/tests/google-workspace-mcp/unit/services/calendar/test_get_events.py
+++ b/tests/google-workspace-mcp/unit/services/calendar/test_get_events.py
@@ -9,6 +9,38 @@ import pytz
 from googleapiclient.errors import HttpError
 
 
+class TestCalendarGetEventsPagination:
+    """Pagination: events past the first page must not be silently truncated."""
+
+    def test_follows_next_page_token(self, mock_calendar_service):
+        page1 = {"items": [{"id": "a"}, {"id": "b"}], "nextPageToken": "tok"}
+        page2 = {"items": [{"id": "c"}]}
+        mock_calendar_service.service.events.return_value.list.return_value.execute.side_effect = [
+            page1,
+            page2,
+        ]
+
+        result = mock_calendar_service.get_events(
+            calendar_id="primary", max_results=3
+        )
+
+        assert [e["id"] for e in result] == ["a", "b", "c"]
+        assert mock_calendar_service.service.events.return_value.list.call_count == 2
+
+    def test_stops_when_desired_total_reached(self, mock_calendar_service):
+        page1 = {"items": [{"id": "a"}, {"id": "b"}, {"id": "c"}], "nextPageToken": "tok"}
+        mock_calendar_service.service.events.return_value.list.return_value.execute.side_effect = [
+            page1
+        ]
+
+        result = mock_calendar_service.get_events(
+            calendar_id="primary", max_results=2
+        )
+
+        assert [e["id"] for e in result] == ["a", "b"]
+        assert mock_calendar_service.service.events.return_value.list.call_count == 1
+
+
 class TestCalendarGetEvents:
     """Tests for the CalendarService.get_events method."""
 

--- a/tests/google-workspace-mcp/unit/services/drive/test_search_files.py
+++ b/tests/google-workspace-mcp/unit/services/drive/test_search_files.py
@@ -8,6 +8,35 @@ from google_workspace_mcp.services.drive import DriveService
 from googleapiclient.errors import HttpError
 
 
+class TestDriveSearchPagination:
+    """Pagination: results past the first page must not be silently lost."""
+
+    def test_follows_next_page_token(self, mock_drive_service: DriveService):
+        page1 = {"files": [{"id": "a"}, {"id": "b"}], "nextPageToken": "tok"}
+        page2 = {"files": [{"id": "c"}, {"id": "d"}]}
+        mock_drive_service.service.files.return_value.list.return_value.execute.side_effect = [
+            page1,
+            page2,
+        ]
+
+        result = mock_drive_service.search_files(query="q", page_size=4)
+
+        assert [f["id"] for f in result] == ["a", "b", "c", "d"]
+        assert mock_drive_service.service.files.return_value.list.call_count == 2
+
+    def test_stops_at_desired_total(self, mock_drive_service: DriveService):
+        page1 = {"files": [{"id": "a"}, {"id": "b"}, {"id": "c"}], "nextPageToken": "tok"}
+        mock_drive_service.service.files.return_value.list.return_value.execute.side_effect = [
+            page1
+        ]
+
+        # Only 2 wanted; first page already satisfies it, no second call.
+        result = mock_drive_service.search_files(query="q", page_size=2)
+
+        assert [f["id"] for f in result] == ["a", "b"]
+        assert mock_drive_service.service.files.return_value.list.call_count == 1
+
+
 class TestDriveSearchFiles:
     """Tests for the DriveService.search_files method."""
 

--- a/tests/google-workspace-mcp/unit/services/drive/test_write_operations.py
+++ b/tests/google-workspace-mcp/unit/services/drive/test_write_operations.py
@@ -81,6 +81,15 @@ class TestDriveWriteOperations:
         assert result["message"] == "Invalid base64 encoded content provided."
         assert result["operation"] == "upload_file_content"
 
+    def test_upload_file_content_empty_decoded_bytes(self, mock_drive_service):
+        """An empty base64 string decodes to 0 bytes and must be rejected."""
+        result = mock_drive_service.upload_file_content("empty.txt", "")
+
+        mock_drive_service.service.files.return_value.create.assert_not_called()
+        assert result["error"] is True
+        assert result["error_type"] == "invalid_content"
+        assert "empty" in result["message"].lower()
+
     @patch("mimetypes.guess_type")
     def test_upload_file_content_unknown_mime_type(
         self, mock_guess_type, mock_drive_service

--- a/tests/google-workspace-mcp/unit/services/gmail/test_drafts.py
+++ b/tests/google-workspace-mcp/unit/services/gmail/test_drafts.py
@@ -112,8 +112,12 @@ class TestGmailDrafts:
             userId="me", id=draft_id
         )
 
-        # For draft deletion, the method returns False on error (it doesn't use handle_api_error)
-        assert result is False
+        # delete_draft now returns the error dict (surfacing Google's real
+        # message) rather than a bare False, so callers can report it.
+        assert isinstance(result, dict)
+        assert result["error"] is True
+        assert result["error_code"] == "NOT_FOUND"
+        assert result["message"] == "Draft not found"
 
     def test_send_draft_success(self, mock_gmail_service):
         """Test successful draft sending."""


### PR DESCRIPTION
> **Stacked on #25** (base error-handling) — it depends on the normalized `error_code`. Review/merge #25 first; base will retarget to `main` automatically once #25 lands.

## What changed
- **Drive search pagination**: ignored `nextPageToken`, silently dropping results past the first page. Now loops on the token up to the requested total (per-request pageSize capped at the API max of 1000).
- **Calendar pagination + silent cap**: same `nextPageToken` bug plus a silent 2500 clamp — >250 events were truncated. Now paginates up to the requested total.
- **Empty uploads**: Drive upload validated the base64 STRING was non-empty but not the DECODED bytes, so an empty string uploaded a 0-byte file. Now rejects empty decoded content (also catches a blob lost in transit).
- **Real delete errors**: `delete_event` / `delete_draft` returned a bare `False` and the tool read a never-set `last_error` attribute, so the real error was always lost. Now return the error dict and the tools raise Google's actual message.
- **A1 validation**: `sheets_read_range` description clarified and inputs with no cell reference rejected up front instead of producing an opaque Google 400.

## Tests
Pagination (token-following + stop-at-total), empty-upload rejection, and updated delete-error tests asserting the surfaced message/code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pagination in Drive and Calendar, blocks 0‑byte Drive uploads, surfaces real delete errors in Calendar and Gmail, and clarifies Sheets read range without over‑restricting A1 input.

- **Bug Fixes**
  - Drive search: follow nextPageToken up to the requested total; per-call max 1000.
  - Calendar `get_events`: paginate to the desired total; remove the silent 2500 clamp; per-call max 2500.
  - Drive uploads: reject empty decoded bytes; return `invalid_content` with a clear message.
  - Calendar `delete_event` and Gmail `delete_draft`: return an error dict on failure; tools raise Google’s message.
  - Sheets `sheets_read_range`: clearer description; accept tab names and named ranges; keep only the empty-input guard and let the API validate malformed ranges.

<sup>Written for commit 36d6d6fb40372aa6e7931725166aa12261300573. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Arclio/arclio-mcp-tooling/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

