### PR TITLE
feat(slides): expose add_image tool, fix italic regex, drop credential cache

### DIFF
--- a/packages/google-workspace-mcp/src/google_workspace_mcp/auth/gauth.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/auth/gauth.py
@@ -6,7 +6,6 @@ Handles OAuth 2.0 authentication using environment variables.
 
 import logging
 import os
-from functools import lru_cache
 
 import google.auth.exceptions
 import google.auth.transport.requests
@@ -15,13 +14,15 @@ from google.oauth2.credentials import Credentials
 logger = logging.getLogger(__name__)
 
 
-@lru_cache(maxsize=32)
 def get_credentials():
     """
     Retrieves Google OAuth credentials from environment variables.
 
-    The credentials are cached to avoid redundant processing, but will
-    be automatically refreshed when expired.
+    Builds a fresh Credentials object from the environment on each call. This is
+    cheap (no network) and intentionally NOT cached: a cache keyed on no args
+    would ignore an env-var token rotation mid-process, and in any shared model
+    would risk serving one identity's credentials to another. The google-auth
+    library refreshes the short-lived access token automatically on use.
 
     Returns:
         google.oauth2.credentials.Credentials: Initialized credentials object.

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/slides.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/slides.py
@@ -320,8 +320,11 @@ class SlidesService(BaseGoogleService):
                             }
                         )
 
-                # Process italic text (making sure not to process text inside bold markers)
-                italic_pattern = r"\*(.*?)\*"
+                # Process italic text. Match a SINGLE asterisk pair only: the
+                # delimiters must not be adjacent to another asterisk, so the
+                # inner markers of **bold** are not picked up as italic. The
+                # bold-containment guard below is a second line of defense.
+                italic_pattern = r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)"
                 italic_matches = list(re.finditer(italic_pattern, formatted_text))
 
                 for match in italic_matches:

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/slides.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/slides.py
@@ -697,9 +697,6 @@ class SlidesService(BaseGoogleService):
             Response data or error information
         """
         try:
-            # Create a unique element ID
-            f"image_{slide_id}_{hash(image_url) % 10000}"
-
             # Define the base request
             create_image_request = {
                 "createImage": {

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/tools/slides.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/tools/slides.py
@@ -476,3 +476,57 @@ async def create_presentation_from_markdown(
         raise ValueError(result.get("message", "Error creating presentation from Markdown"))
 
     return result
+
+
+@mcp.tool(
+    name="add_image_to_slide",
+    description="Adds an image from a public URL to a slide in a Google Slides presentation.",
+)
+async def add_image_to_slide(
+    presentation_id: str,
+    slide_id: str,
+    image_url: str,
+    position_x: float = 100.0,
+    position_y: float = 100.0,
+    size_width: float | None = None,
+    size_height: float | None = None,
+) -> dict[str, Any]:
+    """
+    Add an image to a slide from a publicly accessible URL.
+
+    Args:
+        presentation_id: The ID of the presentation.
+        slide_id: The ID of the slide (page object ID) to place the image on.
+        image_url: Publicly accessible URL of the image (https).
+        position_x: X coordinate in PT (default 100.0).
+        position_y: Y coordinate in PT (default 100.0).
+        size_width: Optional image width in PT. If omitted, Slides uses the
+            image's native size.
+        size_height: Optional image height in PT. Provide together with width.
+
+    Returns:
+        Response data including the created image's ID, or raises an error.
+    """
+    logger.info(f"Executing add_image_to_slide on slide '{slide_id}'")
+    if not presentation_id or not slide_id or not image_url:
+        raise ValueError("Presentation ID, Slide ID, and image URL are required")
+    if (size_width is None) != (size_height is None):
+        raise ValueError(
+            "Provide both size_width and size_height, or neither."
+        )
+
+    size = (size_width, size_height) if size_width is not None else None
+
+    slides_service = SlidesService()
+    result = slides_service.add_image(
+        presentation_id=presentation_id,
+        slide_id=slide_id,
+        image_url=image_url,
+        position=(position_x, position_y),
+        size=size,
+    )
+
+    if isinstance(result, dict) and result.get("error"):
+        raise ValueError(result.get("message", "Error adding image to slide"))
+
+    return result

--- a/tests/google-workspace-mcp/unit/services/slides/test_add_image.py
+++ b/tests/google-workspace-mcp/unit/services/slides/test_add_image.py
@@ -1,0 +1,54 @@
+"""
+Unit tests for SlidesService.add_image.
+
+The service method existed but was never exposed as a tool (agents couldn't
+insert images). These verify the createImage batchUpdate request is built
+correctly, including the optional size.
+"""
+
+
+def _batch_body(mock_slides_service):
+    _, kwargs = mock_slides_service.service.presentations.return_value.batchUpdate.call_args
+    return kwargs["body"]["requests"]
+
+
+class TestAddImage:
+    def test_creates_image_request(self, mock_slides_service):
+        mock_slides_service.service.presentations.return_value.batchUpdate.return_value.execute.return_value = {
+            "replies": [{"createImage": {"objectId": "img1"}}]
+        }
+
+        result = mock_slides_service.add_image(
+            presentation_id="p1",
+            slide_id="s1",
+            image_url="https://example.com/a.png",
+            position=(120, 140),
+        )
+
+        assert result["imageId"] == "img1"
+        assert result["result"] == "success"
+        req = _batch_body(mock_slides_service)[0]["createImage"]
+        assert req["url"] == "https://example.com/a.png"
+        assert req["elementProperties"]["pageObjectId"] == "s1"
+        transform = req["elementProperties"]["transform"]
+        assert transform["translateX"] == 120
+        assert transform["translateY"] == 140
+        # No size requested -> no size key.
+        assert "size" not in req["elementProperties"]
+
+    def test_includes_size_when_given(self, mock_slides_service):
+        mock_slides_service.service.presentations.return_value.batchUpdate.return_value.execute.return_value = {
+            "replies": [{"createImage": {"objectId": "img2"}}]
+        }
+
+        mock_slides_service.add_image(
+            presentation_id="p1",
+            slide_id="s1",
+            image_url="https://example.com/b.png",
+            size=(300, 200),
+        )
+
+        req = _batch_body(mock_slides_service)[0]["createImage"]
+        size = req["elementProperties"]["size"]
+        assert size["width"]["magnitude"] == 300
+        assert size["height"]["magnitude"] == 200


### PR DESCRIPTION
## What changed
- **`add_image_to_slide`**: `add_image` existed in `SlidesService` but had no tool, so agents could not insert images into slides. Now exposed (URL + position + optional size). Also removed dead code in the service method.
- **Italic regex**: `\*(.*?)\*` matched the inner asterisks of `**bold**`, producing spurious style ranges in `add_formatted_text`. Now requires single asterisks not adjacent to another asterisk.
- **Credential cache**: removed `@lru_cache` on `get_credentials()` — keyed on no args it would ignore an env-var token rotation mid-process and, in any shared model, risk serving one identity's creds to another. Building creds is cheap (no network); google-auth refreshes the access token on use.

## Note on the markdown converter
Other markdown-converter issues flagged for `utils/markdown_slides.py` (nested lists, table thead, slide separators) are in dead code — the live markdown path delegates to the `markdowndeck` library, not `MarkdownSlidesConverter` — so they belong in that package, not here.

## Tests
2 new `add_image` service tests (createImage request shape, optional size); italic fix verified against bold/italic mix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposed a new `add_image_to_slide` tool so agents can insert images into Google Slides, and fixed italic parsing that misread `**bold**`. Also removed credential caching to prevent stale tokens and identity mix-ups.

- **New Features**
  - Added `add_image_to_slide` in `google_workspace_mcp/tools/slides.py` to insert an image by URL with position (pt) and optional size; validates width/height pairing and returns the image ID.

- **Bug Fixes**
  - Updated italic regex in `SlidesService.add_formatted_text` to match only single-asterisk pairs, avoiding matches inside `**bold**`.
  - Removed `@lru_cache` from `get_credentials()` in `auth/gauth.py` to honor env var rotations and avoid cross-identity credential reuse (google-auth handles token refresh).
  - Removed dead code in `SlidesService.add_image`.

<sup>Written for commit 7a766f6bc1948353e6ef7af2b25f63e56be7b2e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Arclio/arclio-mcp-tooling/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

