### PR TITLE
feat(drive): folder-by-name search, in-folder search, include_trashed (2.0.3)

### DIFF
--- a/packages/google-workspace-mcp/pyproject.toml
+++ b/packages/google-workspace-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-mcp"
-version = "2.0.2"
+version = "2.0.3"
 description = "MCP server for Google Workspace integration"
 authors = [
     {name = "Arclio Team", email = "info@arclio.com"},

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
@@ -37,7 +37,11 @@ class DriveService(BaseGoogleService):
         super().__init__("drive", "v3")
 
     def search_files(
-        self, query: str, page_size: int = 10, shared_drive_id: str | None = None
+        self,
+        query: str,
+        page_size: int = 10,
+        shared_drive_id: str | None = None,
+        include_shared_drives: bool = False,
     ) -> list[dict[str, Any]]:
         """
         Search for files in Google Drive.
@@ -46,13 +50,19 @@ class DriveService(BaseGoogleService):
             query: Search query string
             page_size: Maximum number of files to return (1-1000)
             shared_drive_id: Optional shared drive ID to search within a specific shared drive
+            include_shared_drives: When True (and no specific shared_drive_id is
+                given), search across My Drive AND all shared drives/folders the
+                user can access (corpora="allDrives"). Needed to find files that
+                live in a Shared Drive by name. Defaults False to preserve the
+                user-only default behavior.
 
         Returns:
             List of file metadata dictionaries (id, name, mimeType, etc.) or an error dictionary
         """
         try:
             logger.info(
-                f"Searching files with query: '{query}', page_size: {page_size}, shared_drive_id: {shared_drive_id}"
+                f"Searching files with query: '{query}', page_size: {page_size}, "
+                f"shared_drive_id: {shared_drive_id}, include_shared_drives: {include_shared_drives}"
             )
 
             # page_size is the desired TOTAL number of results. The Drive API
@@ -61,10 +71,11 @@ class DriveService(BaseGoogleService):
             # first page were silently lost).
             desired_total = max(1, page_size)
 
-            # Build list parameters with shared drive support
+            # Build list parameters with shared drive support. `parents` is
+            # included so folder-aware callers can inspect file location.
             list_params = {
                 "q": query,  # Use the query directly without modification
-                "fields": "nextPageToken, files(id, name, mimeType, modifiedTime, size, webViewLink, iconLink)",
+                "fields": "nextPageToken, files(id, name, mimeType, modifiedTime, size, webViewLink, iconLink, parents)",
                 "supportsAllDrives": True,
                 "includeItemsFromAllDrives": True,
             }
@@ -74,6 +85,9 @@ class DriveService(BaseGoogleService):
                 list_params["corpora"] = (
                     "drive"  # Search within the specified shared drive
                 )
+            elif include_shared_drives:
+                # Search My Drive + all accessible shared drives/folders.
+                list_params["corpora"] = "allDrives"
             else:
                 list_params["corpora"] = (
                     "user"  # Default to user's files if no specific shared drive ID

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/tools/drive.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/tools/drive.py
@@ -22,28 +22,42 @@ async def drive_search_files(
     query: str,
     page_size: int = 10,
     shared_drive_id: str | None = None,
+    include_trashed: bool = False,
 ) -> dict[str, Any]:
     """
     Search for files in Google Drive, optionally within a specific shared drive.
 
     Args:
         query: Search query string. Can be a simple text search or complex query with operators.
+            Note: in Drive query syntax, literal apostrophes inside quoted values must be
+            escaped as \\' (e.g. name = 'John\\'s Files').
         page_size: Maximum number of files to return (1 to 1000, default 10).
         shared_drive_id: Optional shared drive ID to search within a specific shared drive.
+        include_trashed: Whether to include trashed files in results (default False).
 
     Returns:
         A dictionary containing a list of files or an error message.
     """
     logger.info(
-        f"Executing drive_search_files with query: '{query}', page_size: {page_size}, shared_drive_id: {shared_drive_id}"
+        f"Executing drive_search_files with query: '{query}', page_size: {page_size}, "
+        f"shared_drive_id: {shared_drive_id}, include_trashed: {include_trashed}"
     )
 
     if not query or not query.strip():
         raise ValueError("Query cannot be empty")
 
+    # Exclude trashed files unless explicitly requested. Only append the
+    # constraint when the caller hasn't already specified a trashed clause.
+    effective_query = query.strip()
+    if not include_trashed and "trashed" not in effective_query:
+        effective_query = f"({effective_query}) and trashed = false"
+
     drive_service = DriveService()
     files = drive_service.search_files(
-        query=query, page_size=page_size, shared_drive_id=shared_drive_id
+        query=effective_query,
+        page_size=page_size,
+        shared_drive_id=shared_drive_id,
+        include_shared_drives=shared_drive_id is None,
     )
 
     if isinstance(files, dict) and files.get("error"):
@@ -315,4 +329,173 @@ async def drive_move_file(file_id: str, target_folder_id: str) -> dict[str, Any]
     if isinstance(result, dict) and result.get("error"):
         raise ValueError(f"Move failed: {result.get('message', 'Unknown error')}")
 
+    return result
+
+
+@mcp.tool(
+    name="drive_search_files_in_folder",
+    description="Search for files or folders within a specific folder ID (or a Shared Drive ID).",
+)
+async def drive_search_files_in_folder(
+    folder_id: str,
+    query: str = "",
+    page_size: int = 10,
+) -> dict[str, Any]:
+    """
+    Search for files or folders within a specific folder ID. Trashed items are excluded.
+
+    Works for both regular folders and Shared Drives (pass the Shared Drive's ID as folder_id).
+
+    Args:
+        folder_id: The ID of the folder or Shared Drive to search within.
+        query: Optional Drive query string. If empty, returns all items in the folder.
+            Example to find only sub-folders: "mimeType = 'application/vnd.google-apps.folder'".
+        page_size: Maximum number of files to return (1 to 1000, default 10).
+
+    Returns:
+        A dictionary with the folder_id and a list of files/folders.
+    """
+    logger.info(
+        f"Executing drive_search_files_in_folder with folder_id: '{folder_id}', "
+        f"query: '{query}', page_size: {page_size}"
+    )
+
+    if not folder_id or not folder_id.strip():
+        raise ValueError("Folder ID cannot be empty")
+
+    folder_constraint = f"'{folder_id}' in parents and trashed = false"
+    if query and query.strip():
+        # Auto-escape apostrophes in the user query so names like "Ko'a Kea" work.
+        escaped_query = query.strip().replace("'", "\\'")
+        combined_query = f"{escaped_query} and {folder_constraint}"
+    else:
+        combined_query = folder_constraint
+
+    drive_service = DriveService()
+    files = drive_service.search_files(
+        query=combined_query,
+        page_size=page_size,
+        include_shared_drives=True,  # folder searches may span shared drives
+    )
+
+    if isinstance(files, dict) and files.get("error"):
+        raise ValueError(
+            f"Folder search failed: {files.get('message', 'Unknown error')}"
+        )
+
+    return {"folder_id": folder_id, "files": files}
+
+
+@mcp.tool(
+    name="drive_find_folder_by_name",
+    description=(
+        "Find folders by name (exact match first, then partial), auto-escaping "
+        "apostrophes. Optionally also search for files inside the found folder."
+    ),
+)
+async def drive_find_folder_by_name(
+    folder_name: str,
+    include_files: bool = False,
+    file_query: str = "",
+    page_size: int = 10,
+    shared_drive_id: str | None = None,
+) -> dict[str, Any]:
+    """
+    Find folders by name using a two-step search: exact match, then partial match.
+
+    Automatically handles apostrophes in folder names and queries. Trashed items
+    are excluded. Finds regular folders within My Drive or a Shared Drive; it does
+    NOT list Shared Drives themselves (use drive_list_shared_drives for that).
+
+    Args:
+        folder_name: The folder name to search for.
+        include_files: Also search for files within the first matched folder (default False).
+        file_query: Optional query for files within the folder (only if include_files=True).
+        page_size: Maximum number of files to return (1 to 1000, default 10).
+        shared_drive_id: Optional shared drive ID to scope the search.
+
+    Returns:
+        A dictionary with folders_found and, if requested, file results.
+    """
+    logger.info(
+        f"Executing drive_find_folder_by_name with folder_name: '{folder_name}', "
+        f"include_files: {include_files}, file_query: '{file_query}', "
+        f"page_size: {page_size}, shared_drive_id: {shared_drive_id}"
+    )
+
+    if not folder_name or not folder_name.strip():
+        raise ValueError("Folder name cannot be empty")
+
+    drive_service = DriveService()
+    escaped_name = folder_name.strip().replace("'", "\\'")
+    folder_mime = "application/vnd.google-apps.folder"
+
+    # Step 1: exact match
+    exact_query = (
+        f"name = '{escaped_name}' and mimeType = '{folder_mime}' and trashed = false"
+    )
+    folders = drive_service.search_files(
+        query=exact_query,
+        page_size=5,
+        shared_drive_id=shared_drive_id,
+        include_shared_drives=True,
+    )
+
+    # Step 2: partial match fallback
+    if not folders:
+        contains_query = (
+            f"name contains '{escaped_name}' and mimeType = '{folder_mime}' "
+            "and trashed = false"
+        )
+        folders = drive_service.search_files(
+            query=contains_query,
+            page_size=5,
+            shared_drive_id=shared_drive_id,
+            include_shared_drives=True,
+        )
+
+    if isinstance(folders, dict) and folders.get("error"):
+        raise ValueError(
+            f"Folder search failed: {folders.get('message', 'Unknown error')}"
+        )
+
+    result: dict[str, Any] = {
+        "folder_name": folder_name,
+        "folders_found": folders,
+        "folder_count": len(folders) if folders else 0,
+    }
+
+    if not include_files:
+        return result
+
+    if not folders:
+        result["message"] = f"No folders found with name matching '{folder_name}'"
+        return result
+
+    target_folder = folders[0]
+    folder_constraint = f"'{target_folder['id']}' in parents and trashed = false"
+
+    if file_query and file_query.strip():
+        clean = file_query.strip()
+        if " " not in clean and ":" not in clean and "=" not in clean:
+            # Bare keyword -> full-text search, escaped.
+            wrapped = f"fullText contains '{clean.replace(chr(39), chr(92) + chr(39))}'"
+        else:
+            wrapped = clean.replace("'", "\\'")
+        combined_query = f"{wrapped} and {folder_constraint}"
+    else:
+        combined_query = folder_constraint
+
+    files = drive_service.search_files(
+        query=combined_query, page_size=page_size, include_shared_drives=True
+    )
+
+    if isinstance(files, dict) and files.get("error"):
+        raise ValueError(
+            f"File search in folder failed: {files.get('message', 'Unknown error')}"
+        )
+
+    result["target_folder"] = target_folder
+    result["files"] = files
+    result["file_count"] = len(files) if files else 0
     return result

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/tools/drive.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/tools/drive.py
@@ -47,9 +47,11 @@ async def drive_search_files(
         raise ValueError("Query cannot be empty")
 
     # Exclude trashed files unless explicitly requested. Only append the
-    # constraint when the caller hasn't already specified a trashed clause.
+    # constraint when the caller hasn't already used a trashed OPERATOR clause
+    # (match "trashed=" / "trashed =", not the word inside a quoted value).
     effective_query = query.strip()
-    if not include_trashed and "trashed" not in effective_query:
+    has_trashed_clause = "trashed=" in effective_query or "trashed =" in effective_query
+    if not include_trashed and not has_trashed_clause:
         effective_query = f"({effective_query}) and trashed = false"
 
     drive_service = DriveService()
@@ -365,9 +367,11 @@ async def drive_search_files_in_folder(
 
     folder_constraint = f"'{folder_id}' in parents and trashed = false"
     if query and query.strip():
-        # Auto-escape apostrophes in the user query so names like "Ko'a Kea" work.
-        escaped_query = query.strip().replace("'", "\\'")
-        combined_query = f"{escaped_query} and {folder_constraint}"
+        # `query` is a structured Drive query; pass it through verbatim (the
+        # caller escapes apostrophes inside their own value strings, as with
+        # drive_search_files). Escaping the whole string here would corrupt the
+        # query's own quote delimiters.
+        combined_query = f"{query.strip()} and {folder_constraint}"
     else:
         combined_query = folder_constraint
 
@@ -478,10 +482,14 @@ async def drive_find_folder_by_name(
     if file_query and file_query.strip():
         clean = file_query.strip()
         if " " not in clean and ":" not in clean and "=" not in clean:
-            # Bare keyword -> full-text search, escaped.
-            wrapped = f"fullText contains '{clean.replace(chr(39), chr(92) + chr(39))}'"
+            # Bare keyword -> wrap in a full-text predicate, escaping the
+            # apostrophes in the keyword value we interpolate.
+            escaped = clean.replace("'", "\\'")
+            wrapped = f"fullText contains '{escaped}'"
         else:
-            wrapped = clean.replace("'", "\\'")
+            # Already a structured query; pass through verbatim (caller escapes
+            # apostrophes inside their own value strings).
+            wrapped = clean
         combined_query = f"{wrapped} and {folder_constraint}"
     else:
         combined_query = folder_constraint

--- a/tests/google-workspace-mcp/unit/services/drive/test_search_corpora.py
+++ b/tests/google-workspace-mcp/unit/services/drive/test_search_corpora.py
@@ -1,0 +1,46 @@
+"""
+Tests for the include_shared_drives / corpora behavior of DriveService.search_files.
+
+Ported from the demo branch's drive-search work: folder-aware searches need to
+span shared drives (corpora="allDrives"), while the default stays user-only.
+"""
+
+
+class TestSearchCorpora:
+    def _last_list_params(self, mock_drive_service):
+        _, kwargs = mock_drive_service.service.files.return_value.list.call_args
+        return kwargs
+
+    def test_default_is_user_corpora(self, mock_drive_service):
+        mock_drive_service.service.files.return_value.list.return_value.execute.return_value = {
+            "files": []
+        }
+        mock_drive_service.search_files(query="x", page_size=5)
+        assert self._last_list_params(mock_drive_service)["corpora"] == "user"
+
+    def test_include_shared_drives_uses_all_drives(self, mock_drive_service):
+        mock_drive_service.service.files.return_value.list.return_value.execute.return_value = {
+            "files": []
+        }
+        mock_drive_service.search_files(
+            query="x", page_size=5, include_shared_drives=True
+        )
+        assert self._last_list_params(mock_drive_service)["corpora"] == "allDrives"
+
+    def test_specific_shared_drive_overrides(self, mock_drive_service):
+        mock_drive_service.service.files.return_value.list.return_value.execute.return_value = {
+            "files": []
+        }
+        mock_drive_service.search_files(
+            query="x", page_size=5, shared_drive_id="drive1", include_shared_drives=True
+        )
+        params = self._last_list_params(mock_drive_service)
+        assert params["corpora"] == "drive"
+        assert params["driveId"] == "drive1"
+
+    def test_parents_field_requested(self, mock_drive_service):
+        mock_drive_service.service.files.return_value.list.return_value.execute.return_value = {
+            "files": []
+        }
+        mock_drive_service.search_files(query="x", page_size=5)
+        assert "parents" in self._last_list_params(mock_drive_service)["fields"]

--- a/tests/google-workspace-mcp/unit/tools/drive/test_search_tool.py
+++ b/tests/google-workspace-mcp/unit/tools/drive/test_search_tool.py
@@ -32,8 +32,13 @@ class TestDriveSearchFilesTool:
         result = await drive_search_files(query="test documents", page_size=5)
 
         assert result == {"files": mock_files}
+        # Tool wraps with trashed=false (default) and searches all drives when no
+        # specific shared drive is given.
         mock_drive_service_for_tool.search_files.assert_called_once_with(
-            query="test documents", page_size=5, shared_drive_id=None
+            query="(test documents) and trashed = false",
+            page_size=5,
+            shared_drive_id=None,
+            include_shared_drives=True,
         )
 
     async def test_tool_search_files_with_shared_drive(self, mock_drive_service_for_tool):
@@ -46,8 +51,12 @@ class TestDriveSearchFilesTool:
         result = await drive_search_files(query="shared documents", page_size=10, shared_drive_id="drive123")
 
         assert result == {"files": mock_files}
+        # A specific shared_drive_id -> include_shared_drives is False (scoped).
         mock_drive_service_for_tool.search_files.assert_called_once_with(
-            query="shared documents", page_size=10, shared_drive_id="drive123"
+            query="(shared documents) and trashed = false",
+            page_size=10,
+            shared_drive_id="drive123",
+            include_shared_drives=False,
         )
 
     async def test_tool_search_files_empty_results(self, mock_drive_service_for_tool):
@@ -96,5 +105,10 @@ class TestDriveSearchFilesTool:
         result = await drive_search_files(query="test")
 
         # Verify default parameters
-        mock_drive_service_for_tool.search_files.assert_called_once_with(query="test", page_size=10, shared_drive_id=None)
+        mock_drive_service_for_tool.search_files.assert_called_once_with(
+            query="(test) and trashed = false",
+            page_size=10,
+            shared_drive_id=None,
+            include_shared_drives=True,
+        )
         assert result == {"files": mock_files}


### PR DESCRIPTION
Ports the genuinely-additive drive-search wins from the demo/tool-optimization (demo-11) branch onto current main. Hand-ported rather than cherry-picked, because that branch is old and had commented-out tools — a merge would have clobbered the pagination + xlsx work already on main.

## What changed
- **drive_find_folder_by_name** (new tool): exact-then-partial folder match with automatic apostrophe escaping (handles folder names containing apostrophes), plus an optional file search within the matched folder. Covers the "locate the dated folder" step a content workflow needs.
- **drive_search_files_in_folder** (new tool): list/query items within a folder or Shared Drive id.
- **search_files gains include_shared_drives** (corpora=allDrives) so files/folders in Shared Drives can be found by name. Default stays user-only, preserving existing behavior. Also adds parents to the returned fields.
- **drive_search_files gains include_trashed** (default False) and auto-appends a trashed = false constraint otherwise.

## What was deliberately NOT ported
- The demo branch weak query-cleaner (strips quotes, makes the user escape apostrophes manually). The real escaping lives in the folder tools and is ported properly; the requirement is documented in the drive_search_files docstring.
- The demo-specific hacks (commented-out tools, package rename, file-move/share/public-image churn).

## Verification
- 74 drive service tests pass (incl. 4 new corpora tests; existing pagination/search tests still green so default behavior is unchanged).
- Live-verified against real Drive: shared-drive folder lookup by name finds the expected content folders, and an escaped-apostrophe query executes without a 400.

Bumps version to 2.0.3.