### PR TITLE
feat(drive): return webContentLink from drive_search_files (2.0.4)

### DIFF
--- a/packages/google-workspace-mcp/pyproject.toml
+++ b/packages/google-workspace-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-mcp"
-version = "2.0.3"
+version = "2.0.4"
 description = "MCP server for Google Workspace integration"
 authors = [
     {name = "Arclio Team", email = "info@arclio.com"},

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
@@ -73,9 +73,15 @@ class DriveService(BaseGoogleService):
 
             # Build list parameters with shared drive support. `parents` is
             # included so folder-aware callers can inspect file location.
+            # `webContentLink` is the direct-download URL (present for binary
+            # files shared "Anyone with the link"); callers that move bytes
+            # server-side — e.g. a media-upload pipeline chaining the link into
+            # another service — need it so the file never has to be downloaded
+            # through the agent. `webViewLink` is the human viewer page, not a
+            # fetchable asset.
             list_params = {
                 "q": query,  # Use the query directly without modification
-                "fields": "nextPageToken, files(id, name, mimeType, modifiedTime, size, webViewLink, iconLink, parents)",
+                "fields": "nextPageToken, files(id, name, mimeType, modifiedTime, size, webViewLink, webContentLink, iconLink, parents)",
                 "supportsAllDrives": True,
                 "includeItemsFromAllDrives": True,
             }


### PR DESCRIPTION
## Problem
`drive_search_files` returned `webViewLink` (the human viewer page) but **not** `webContentLink` (the direct-download URL). Agents that move bytes server-side — e.g. chaining a Drive asset into another service's media-upload call so a large file never downloads *through* the agent — had no fetchable URL and were forced through `drive_read_file_content` (pull-through-process), which blows context/size limits on video.

## Fix
Add `webContentLink` to the `search_files` field set. It is already requested in `get_file_metadata`, so this just brings list parity. One field, no behavior change for existing callers.

## Verified live
Ran a real `drive_search_files` against staging before the change: the response carried `id, name, mimeType, modifiedTime, size, webViewLink, iconLink, parents` — **no `webContentLink`**. This closes that gap so the field is available to agents.

Bumps `google-workspace-mcp` to **2.0.4**.

## Downstream
Unblocks server-side media-upload chains that need a direct-download URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return `webContentLink` in `drive_search_files` to expose a direct-download URL, enabling server-side media pipelines without pulling bytes through the agent. No breaking changes; bumps `google-workspace-mcp` to 2.0.4.