### PR TITLE
feat(drive): add drive_rename_file tool (2.0.6)

### DIFF
--- a/packages/google-workspace-mcp/pyproject.toml
+++ b/packages/google-workspace-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-mcp"
-version = "2.0.5"
+version = "2.0.6"
 description = "MCP server for Google Workspace integration"
 authors = [
     {name = "Arclio Team", email = "info@arclio.com"},

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
@@ -741,6 +741,47 @@ class DriveService(BaseGoogleService):
                 "operation": "move_file",
             }
 
+    def rename_file(self, file_id: str, new_name: str) -> dict[str, Any]:
+        """
+        Rename an existing Drive file.
+
+        Args:
+            file_id: ID of the file to rename.
+            new_name: The new name for the file.
+
+        Returns:
+            Dict with the file's id, name, and webViewLink, or error information.
+        """
+        try:
+            if not file_id or not file_id.strip():
+                return {"error": True, "message": "file_id is required."}
+            if not new_name or not new_name.strip():
+                return {"error": True, "message": "new_name cannot be empty."}
+
+            logger.info(f"Renaming file {file_id} to '{new_name}'.")
+            updated = (
+                self.service.files()
+                .update(
+                    fileId=file_id,
+                    body={"name": new_name.strip()},
+                    fields="id, name, webViewLink",
+                    supportsAllDrives=True,
+                )
+                .execute()
+            )
+            return updated
+
+        except HttpError as e:
+            return self.handle_api_error("rename_file", e)
+        except Exception as e:
+            logger.error(f"Non-API error in rename_file: {str(e)}")
+            return {
+                "error": True,
+                "error_type": "local_error",
+                "message": f"Error renaming file: {str(e)}",
+                "operation": "rename_file",
+            }
+
     def delete_file(self, file_id: str) -> dict[str, Any]:
         """
         Delete a file from Google Drive.

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/tools/drive.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/tools/drive.py
@@ -347,6 +347,37 @@ async def drive_move_file(file_id: str, target_folder_id: str) -> dict[str, Any]
 
 
 @mcp.tool(
+    name="drive_rename_file",
+    description="Rename an existing Google Drive file.",
+)
+async def drive_rename_file(file_id: str, new_name: str) -> dict[str, Any]:
+    """
+    Rename a Drive file.
+
+    Args:
+        file_id: ID of the file to rename.
+        new_name: The new name for the file.
+
+    Returns:
+        A dictionary with the file's id, name, and webViewLink, or an error.
+    """
+    logger.info(f"Executing drive_rename_file: {file_id} -> '{new_name}'")
+
+    if not file_id or not file_id.strip():
+        raise ValueError("file_id cannot be empty")
+    if not new_name or not new_name.strip():
+        raise ValueError("new_name cannot be empty")
+
+    drive_service = DriveService()
+    result = drive_service.rename_file(file_id=file_id, new_name=new_name)
+
+    if isinstance(result, dict) and result.get("error"):
+        raise ValueError(f"Rename failed: {result.get('message', 'Unknown error')}")
+
+    return result
+
+
+@mcp.tool(
     name="drive_search_files_in_folder",
     description="Search for files or folders within a specific folder ID (or a Shared Drive ID).",
 )

--- a/tests/google-workspace-mcp/unit/services/drive/test_convert_xlsx.py
+++ b/tests/google-workspace-mcp/unit/services/drive/test_convert_xlsx.py
@@ -101,3 +101,26 @@ class TestMoveFile:
     def test_move_requires_both_ids(self, mock_drive_service):
         assert mock_drive_service.move_file("", "dest")["error"] is True
         assert mock_drive_service.move_file("f1", "")["error"] is True
+
+
+class TestRenameFile:
+    def test_rename_updates_name(self, mock_drive_service):
+        mock_drive_service.service.files.return_value.update.return_value.execute.return_value = {
+            "id": "f1",
+            "name": "renamed.pdf",
+            "webViewLink": "http://x",
+        }
+
+        result = mock_drive_service.rename_file("f1", "  renamed.pdf  ")
+
+        _, kwargs = mock_drive_service.service.files.return_value.update.call_args
+        assert kwargs["fileId"] == "f1"
+        assert kwargs["body"] == {"name": "renamed.pdf"}  # trimmed
+        assert kwargs["supportsAllDrives"] is True
+        assert result["name"] == "renamed.pdf"
+
+    def test_rename_requires_id_and_name(self, mock_drive_service):
+        assert mock_drive_service.rename_file("", "x")["error"] is True
+        assert mock_drive_service.rename_file("f1", "")["error"] is True
+        assert mock_drive_service.rename_file("f1", "   ")["error"] is True
+        mock_drive_service.service.files.return_value.update.assert_not_called()


### PR DESCRIPTION
Closes #33.

## Problem
There was no way to rename an existing Drive file through the tools. `drive_upload_file` sets a name on creation, but changing a file's name afterward (e.g. to follow a naming convention) wasn't exposed.

## Fix
Add `drive_rename_file(file_id, new_name)` backed by a `rename_file` service method that calls `files.update(fileId=..., body={"name": ...}, supportsAllDrives=True)` and returns the updated `id`/`name`/`webViewLink`. Mirrors the existing move/upload tool shape, including Shared Drive support and validation (rejects empty id/name).

## Verification
- 79 drive service tests pass (incl. 2 new: rename trims + sends the name; rejects empty id/name without an API call).
- **Live-verified** against real Drive: created a file, renamed it, and confirmed the new name via a subsequent get.

Bumps version to **2.0.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `drive_rename_file` to rename existing Google Drive files after upload. Returns the updated file id, name, and webViewLink.

- **New Features**
  - Added service `rename_file` using Drive `files.update(..., supportsAllDrives=True)` and returning id, name, webViewLink.
  - Validates inputs: non-empty `file_id` and trimmed `new_name`; rejects invalid input without an API call.
  - Added unit tests and live verification; bumped `google-workspace-mcp` to 2.0.6.

<sup>Written for commit d67d61697dae67096a6fefac42bb6e72299d07ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Arclio/arclio-mcp-tooling/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

