### PR TITLE
feat(drive): add drive_share_file tool

### DIFF
--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
@@ -782,6 +782,54 @@ class DriveService(BaseGoogleService):
                 "operation": "rename_file",
             }
 
+    def share_file(
+        self, file_id: str, shared_drive_id: str | None = None
+    ) -> dict[str, Any]:
+        """Grant "anyone with the link → reader" on an existing file.
+
+        For files that already exist (uploaded earlier, or created outside this
+        tool) and need to become fetchable by their ``webContentLink`` without
+        authentication. Idempotent — granting access to an already-shared file
+        is a no-op. Returns the file's id + ``webContentLink`` plus the share
+        outcome.
+
+        Args:
+            file_id: ID of the file to share.
+            shared_drive_id: Optional Shared Drive id for ``supportsAllDrives``.
+
+        Returns:
+            Dict with id, webViewLink, webContentLink, shared, and (on failure)
+            share_error; or error information.
+        """
+        try:
+            if not file_id or not file_id.strip():
+                return {"error": True, "message": "file_id is required."}
+
+            logger.info(f"Sharing file {file_id} anyone-with-link → reader.")
+            share = self._grant_anyone_reader(file_id, shared_drive_id)
+
+            meta = (
+                self.service.files()
+                .get(
+                    fileId=file_id,
+                    fields="id, name, webViewLink, webContentLink",
+                    supportsAllDrives=True,
+                )
+                .execute()
+            )
+            return {**meta, **share}
+
+        except HttpError as e:
+            return self.handle_api_error("share_file", e)
+        except Exception as e:
+            logger.error(f"Non-API error in share_file: {str(e)}")
+            return {
+                "error": True,
+                "error_type": "local_error",
+                "message": f"Error sharing file: {str(e)}",
+                "operation": "share_file",
+            }
+
     def delete_file(self, file_id: str) -> dict[str, Any]:
         """
         Delete a file from Google Drive.

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/tools/drive.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/tools/drive.py
@@ -378,6 +378,43 @@ async def drive_rename_file(file_id: str, new_name: str) -> dict[str, Any]:
 
 
 @mcp.tool(
+    name="drive_share_file",
+    description=(
+        "Grant 'anyone with the link → reader' access to an existing Google "
+        "Drive file, so it's fetchable by its webContentLink without "
+        "authentication. Use before handing a file's direct-download URL to an "
+        "external service. Idempotent."
+    ),
+)
+async def drive_share_file(
+    file_id: str, shared_drive_id: str | None = None
+) -> dict[str, Any]:
+    """
+    Share an existing Drive file anyone-with-link → reader.
+
+    Args:
+        file_id: ID of the file to share.
+        shared_drive_id: Optional Shared Drive id (for supportsAllDrives).
+
+    Returns:
+        A dict with id, name, webViewLink, webContentLink, and the share
+        outcome (shared / share_error), or an error.
+    """
+    logger.info(f"Executing drive_share_file: {file_id}")
+
+    if not file_id or not file_id.strip():
+        raise ValueError("file_id cannot be empty")
+
+    drive_service = DriveService()
+    result = drive_service.share_file(file_id=file_id, shared_drive_id=shared_drive_id)
+
+    if isinstance(result, dict) and result.get("error"):
+        raise ValueError(f"Share failed: {result.get('message', 'Unknown error')}")
+
+    return result
+
+
+@mcp.tool(
     name="drive_search_files_in_folder",
     description="Search for files or folders within a specific folder ID (or a Shared Drive ID).",
 )


### PR DESCRIPTION
## Problem
`drive_upload_file` can share a file on creation (the `share` param), but there's no way to share an **existing** file so its `webContentLink` becomes fetchable without authentication. Files created elsewhere (uploaded earlier, added directly in Drive) can't be made link-fetchable through the tools, so handing their direct-download URL to an external service fails.

## Fix
Add `drive_share_file(file_id, shared_drive_id=None)` backed by a `share_file` service method that reuses the existing `_grant_anyone_reader` helper and returns the file's `webContentLink` alongside the share outcome. Idempotent — sharing an already-shared file is a no-op. Version bump 2.0.5 → 2.0.6.

## Test
Share a private file → confirm it's reachable unauthenticated via its returned `webContentLink`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `drive_share_file` to share existing Drive files. This makes their `webContentLink` usable without authentication.

- New Features
  - New tool `drive_share_file(file_id, shared_drive_id?)` that grants anyone-with-link → reader.
  - Service method `share_file` reuses `_grant_anyone_reader`; idempotent.
  - Returns `id`, `name`, `webViewLink`, `webContentLink`, plus `shared` or `share_error`.
  - Supports Shared Drives via `supportsAllDrives`. Bumps package to 2.0.6.

<sup>Written for commit 08d485b3ad0c82f7ab15863c51c69ab389180c56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Arclio/arclio-mcp-tooling/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

