### PR TITLE
feat(drive): non-redirecting download_url for large files (2.0.8)

### DIFF
--- a/packages/google-workspace-mcp/pyproject.toml
+++ b/packages/google-workspace-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-mcp"
-version = "2.0.7"
+version = "2.0.8"
 description = "MCP server for Google Workspace integration"
 authors = [
     {name = "Arclio Team", email = "info@arclio.com"},

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
@@ -31,7 +31,7 @@ NATIVE_SHEET_MIME_TYPE = "application/vnd.google-apps.spreadsheet"
 _GOOGLE_NATIVE_MIME_PREFIX = "application/vnd.google-apps."
 
 
-def _direct_download_url(file_id: str) -> str:
+def _direct_download_url(file_id: str, resource_key: str | None = None) -> str:
     """Build a non-redirecting direct-download URL for a Drive file id.
 
     Drive's ``webContentLink`` (``drive.google.com/uc?...&export=download``)
@@ -39,28 +39,38 @@ def _direct_download_url(file_id: str) -> str:
     videos), which breaks consumers that don't follow redirects. The
     ``drive.usercontent.google.com/download`` host with ``confirm=t`` serves
     the bytes directly with no redirect and no scan interstitial.
+
+    ``resource_key`` is appended when present: files shared "anyone with the
+    link" under Google's resource-key security model require the key in the URL,
+    otherwise an id-only link fails for those files.
     """
-    return (
+    url = (
         f"https://drive.usercontent.google.com/download?id={file_id}"
         "&export=download&confirm=t"
     )
+    if resource_key:
+        url += f"&resourcekey={resource_key}"
+    return url
 
 
 def _with_download_url(file_meta: dict[str, Any]) -> dict[str, Any]:
     """Add a ``download_url`` to a file-metadata dict when applicable.
 
     Adds the non-redirecting direct-download URL (see ``_direct_download_url``)
-    for byte-downloadable files that have an ``id``. Native Google Workspace
-    files (Docs/Sheets/Slides) are skipped since they aren't byte-downloadable;
-    they get ``download_url=None`` so callers can rely on the key existing.
-    Mutates and returns the same dict.
+    for byte-downloadable files that have an ``id``. Preserves a file's
+    ``resourceKey`` when present (required for resource-key-protected shared
+    files). Native Google Workspace files (Docs/Sheets/Slides) are skipped since
+    they aren't byte-downloadable; they get ``download_url=None`` so callers can
+    rely on the key existing. Mutates and returns the same dict.
     """
     if not isinstance(file_meta, dict):
         return file_meta
     file_id = file_meta.get("id")
     mime = file_meta.get("mimeType") or ""
     if file_id and not mime.startswith(_GOOGLE_NATIVE_MIME_PREFIX):
-        file_meta["download_url"] = _direct_download_url(file_id)
+        file_meta["download_url"] = _direct_download_url(
+            file_id, file_meta.get("resourceKey")
+        )
     else:
         file_meta.setdefault("download_url", None)
     return file_meta
@@ -120,7 +130,7 @@ class DriveService(BaseGoogleService):
             # fetchable asset.
             list_params = {
                 "q": query,  # Use the query directly without modification
-                "fields": "nextPageToken, files(id, name, mimeType, modifiedTime, size, webViewLink, webContentLink, iconLink, parents)",
+                "fields": "nextPageToken, files(id, name, mimeType, modifiedTime, size, webViewLink, webContentLink, iconLink, parents, resourceKey)",
                 "supportsAllDrives": True,
                 "includeItemsFromAllDrives": True,
             }
@@ -526,7 +536,7 @@ class DriveService(BaseGoogleService):
             create_params = {
                 "body": file_metadata,
                 "media_body": media,
-                "fields": "id,name,mimeType,modifiedTime,size,webViewLink,webContentLink",
+                "fields": "id,name,mimeType,modifiedTime,size,webViewLink,webContentLink,resourceKey",
                 "supportsAllDrives": True,
             }
             if shared_drive_id:
@@ -619,7 +629,7 @@ class DriveService(BaseGoogleService):
                 self.service.files()
                 .get(
                     fileId=file_id,
-                    fields="id,name,mimeType,modifiedTime,size,webViewLink,webContentLink",
+                    fields="id,name,mimeType,modifiedTime,size,webViewLink,webContentLink,resourceKey",
                     supportsAllDrives=True,
                 )
                 .execute()
@@ -856,7 +866,7 @@ class DriveService(BaseGoogleService):
                 self.service.files()
                 .get(
                     fileId=file_id,
-                    fields="id, name, mimeType, webViewLink, webContentLink",
+                    fields="id, name, mimeType, webViewLink, webContentLink, resourceKey",
                     supportsAllDrives=True,
                 )
                 .execute()

--- a/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
+++ b/packages/google-workspace-mcp/src/google_workspace_mcp/services/drive.py
@@ -26,6 +26,45 @@ XLSX_MIME_TYPE = (
 )
 NATIVE_SHEET_MIME_TYPE = "application/vnd.google-apps.spreadsheet"
 
+# Native Google Workspace types are not byte-downloadable; a download_url for
+# them would be meaningless, so we skip building one for these.
+_GOOGLE_NATIVE_MIME_PREFIX = "application/vnd.google-apps."
+
+
+def _direct_download_url(file_id: str) -> str:
+    """Build a non-redirecting direct-download URL for a Drive file id.
+
+    Drive's ``webContentLink`` (``drive.google.com/uc?...&export=download``)
+    303-redirects to a virus-scan confirmation page for large files (e.g.
+    videos), which breaks consumers that don't follow redirects. The
+    ``drive.usercontent.google.com/download`` host with ``confirm=t`` serves
+    the bytes directly with no redirect and no scan interstitial.
+    """
+    return (
+        f"https://drive.usercontent.google.com/download?id={file_id}"
+        "&export=download&confirm=t"
+    )
+
+
+def _with_download_url(file_meta: dict[str, Any]) -> dict[str, Any]:
+    """Add a ``download_url`` to a file-metadata dict when applicable.
+
+    Adds the non-redirecting direct-download URL (see ``_direct_download_url``)
+    for byte-downloadable files that have an ``id``. Native Google Workspace
+    files (Docs/Sheets/Slides) are skipped since they aren't byte-downloadable;
+    they get ``download_url=None`` so callers can rely on the key existing.
+    Mutates and returns the same dict.
+    """
+    if not isinstance(file_meta, dict):
+        return file_meta
+    file_id = file_meta.get("id")
+    mime = file_meta.get("mimeType") or ""
+    if file_id and not mime.startswith(_GOOGLE_NATIVE_MIME_PREFIX):
+        file_meta["download_url"] = _direct_download_url(file_id)
+    else:
+        file_meta.setdefault("download_url", None)
+    return file_meta
+
 
 class DriveService(BaseGoogleService):
     """
@@ -112,6 +151,8 @@ class DriveService(BaseGoogleService):
                     break
 
             files = files[:desired_total]
+            for f in files:
+                _with_download_url(f)
             logger.info(f"Found {len(files)} files matching query '{query}'")
             return files
 
@@ -515,6 +556,9 @@ class DriveService(BaseGoogleService):
             # (webContentLink is absent for Google-native files and some
             # configurations even when shared).
             file.setdefault("webContentLink", None)
+            # Add the non-redirecting direct-download URL (reliable for large
+            # binary files, unlike webContentLink which 303s).
+            _with_download_url(file)
             return file
 
         except HttpError as e:
@@ -812,12 +856,12 @@ class DriveService(BaseGoogleService):
                 self.service.files()
                 .get(
                     fileId=file_id,
-                    fields="id, name, webViewLink, webContentLink",
+                    fields="id, name, mimeType, webViewLink, webContentLink",
                     supportsAllDrives=True,
                 )
                 .execute()
             )
-            return {**meta, **share}
+            return _with_download_url({**meta, **share})
 
         except HttpError as e:
             return self.handle_api_error("share_file", e)

--- a/tests/google-workspace-mcp/unit/services/drive/test_download_url.py
+++ b/tests/google-workspace-mcp/unit/services/drive/test_download_url.py
@@ -1,0 +1,91 @@
+"""
+Tests for the non-redirecting download_url added to Drive results.
+
+webContentLink (drive.google.com/uc?...&export=download) 303-redirects to a
+virus-scan confirmation page for large files, breaking consumers that don't
+follow redirects. download_url uses drive.usercontent.google.com/download with
+confirm=t, which serves the bytes directly.
+"""
+
+from google_workspace_mcp.services.drive import (
+    _direct_download_url,
+    _with_download_url,
+)
+
+
+class TestDirectDownloadUrl:
+    def test_url_shape(self):
+        url = _direct_download_url("ABC123")
+        assert url == (
+            "https://drive.usercontent.google.com/download?id=ABC123"
+            "&export=download&confirm=t"
+        )
+
+    def test_non_redirecting_host(self):
+        # The whole point: NOT the drive.google.com/uc host that 303s.
+        url = _direct_download_url("x")
+        assert "drive.usercontent.google.com/download" in url
+        assert "uc?id" not in url
+        assert "confirm=t" in url
+
+
+class TestWithDownloadUrl:
+    def test_binary_file_gets_download_url(self):
+        meta = {"id": "fid", "mimeType": "video/mp4"}
+        out = _with_download_url(meta)
+        assert out["download_url"] == _direct_download_url("fid")
+
+    def test_native_google_file_gets_none(self):
+        # Google Docs/Sheets/Slides are not byte-downloadable.
+        meta = {"id": "fid", "mimeType": "application/vnd.google-apps.document"}
+        out = _with_download_url(meta)
+        assert out["download_url"] is None
+
+    def test_missing_id_gets_none(self):
+        out = _with_download_url({"mimeType": "video/mp4"})
+        assert out["download_url"] is None
+
+    def test_missing_mimetype_treated_as_downloadable(self):
+        # No mimeType (e.g. some list responses) -> still build the URL.
+        out = _with_download_url({"id": "fid"})
+        assert out["download_url"] == _direct_download_url("fid")
+
+    def test_returns_same_dict_mutated(self):
+        meta = {"id": "fid", "mimeType": "image/png"}
+        assert _with_download_url(meta) is meta
+
+
+class TestShareFileDownloadUrl:
+    def test_share_file_returns_download_url(self, mock_drive_service):
+        mock_drive_service.service.permissions.return_value.create.return_value.execute.return_value = {}
+        mock_drive_service.service.files.return_value.get.return_value.execute.return_value = {
+            "id": "vid1",
+            "name": "clip.mp4",
+            "mimeType": "video/mp4",
+            "webViewLink": "http://view",
+            "webContentLink": "https://drive.google.com/uc?id=vid1&export=download",
+        }
+
+        result = mock_drive_service.share_file("vid1")
+
+        assert result["shared"] is True
+        assert (
+            result["download_url"]
+            == "https://drive.usercontent.google.com/download?id=vid1"
+            "&export=download&confirm=t"
+        )
+        # webContentLink kept for backward compat.
+        assert "webContentLink" in result
+
+
+class TestSearchDownloadUrl:
+    def test_search_results_carry_download_url(self, mock_drive_service):
+        mock_drive_service.service.files.return_value.list.return_value.execute.return_value = {
+            "files": [
+                {"id": "a", "mimeType": "video/mp4"},
+                {"id": "b", "mimeType": "application/vnd.google-apps.document"},
+            ]
+        }
+        files = mock_drive_service.search_files(query="x", page_size=5)
+        assert files[0]["download_url"] == _direct_download_url("a")
+        assert files[1]["download_url"] is None  # native doc

--- a/tests/google-workspace-mcp/unit/services/drive/test_download_url.py
+++ b/tests/google-workspace-mcp/unit/services/drive/test_download_url.py
@@ -50,6 +50,14 @@ class TestWithDownloadUrl:
         out = _with_download_url({"id": "fid"})
         assert out["download_url"] == _direct_download_url("fid")
 
+    def test_resource_key_appended(self):
+        # Resource-key-protected files need the key in the download URL.
+        out = _with_download_url(
+            {"id": "fid", "mimeType": "video/mp4", "resourceKey": "rk_abc"}
+        )
+        assert out["download_url"].endswith("&resourcekey=rk_abc")
+        assert out["download_url"] == _direct_download_url("fid", "rk_abc")
+
     def test_returns_same_dict_mutated(self):
         meta = {"id": "fid", "mimeType": "image/png"}
         assert _with_download_url(meta) is meta

--- a/tests/google-workspace-mcp/unit/services/drive/test_write_operations.py
+++ b/tests/google-workspace-mcp/unit/services/drive/test_write_operations.py
@@ -54,7 +54,14 @@ class TestDriveWriteOperations:
             supportsAllDrives=True,
         )
         mock_drive_service.service.permissions.return_value.create.assert_not_called()
-        assert result == mock_file_metadata
+        # Even a private (share=False) upload now carries a download_url for the
+        # binary file (text/plain here).
+        assert result["id"] == "uploaded_file_id"
+        assert (
+            result["download_url"]
+            == "https://drive.usercontent.google.com/download?id=uploaded_file_id"
+            "&export=download&confirm=t"
+        )
 
     @patch("mimetypes.guess_type")
     def test_upload_file_content_shared_when_requested(

--- a/tests/google-workspace-mcp/unit/services/drive/test_write_operations.py
+++ b/tests/google-workspace-mcp/unit/services/drive/test_write_operations.py
@@ -50,7 +50,7 @@ class TestDriveWriteOperations:
         mock_drive_service.service.files.return_value.create.assert_called_once_with(
             body={"name": "test.txt"},
             media_body=ANY,
-            fields="id,name,mimeType,modifiedTime,size,webViewLink,webContentLink",
+            fields="id,name,mimeType,modifiedTime,size,webViewLink,webContentLink,resourceKey",
             supportsAllDrives=True,
         )
         mock_drive_service.service.permissions.return_value.create.assert_not_called()
@@ -209,7 +209,7 @@ class TestDriveWriteOperations:
         mock_drive_service.service.files.return_value.create.assert_called_once_with(
             body={"name": "unknown.bin"},
             media_body=ANY,
-            fields="id,name,mimeType,modifiedTime,size,webViewLink,webContentLink",
+            fields="id,name,mimeType,modifiedTime,size,webViewLink,webContentLink,resourceKey",
             supportsAllDrives=True,
         )
         # Verify result
@@ -256,7 +256,7 @@ class TestDriveWriteOperations:
         mock_drive_service.service.files.return_value.create.assert_called_once_with(
             body={"name": "test.txt"},
             media_body=ANY,
-            fields="id,name,mimeType,modifiedTime,size,webViewLink,webContentLink",
+            fields="id,name,mimeType,modifiedTime,size,webViewLink,webContentLink,resourceKey",
             supportsAllDrives=True,
         )
         mock_drive_service.service.files.return_value.create.return_value.execute.assert_called_once()


### PR DESCRIPTION
Closes #36.

## Problem
Drive's `webContentLink` (`drive.google.com/uc?id=<ID>&export=download`) **303-redirects to a virus-scan confirmation page for large files** (e.g. videos). Consumers that don't follow redirects fail with errors like "url returned redirect 303; redirects are not followed." So the raw `webContentLink` is unreliable for binary media.

## Fix
Add a `download_url` field built from the file id:
```
https://drive.usercontent.google.com/download?id=<ID>&export=download&confirm=t
```
This host + `confirm=t` serves the bytes directly with **no redirect** and skips the scan interstitial. `webContentLink` is kept for backward compat.

Applied to the result builders for **`share_file`**, **`upload_file_content`**, and **`search_files`**. Native Google files (Docs/Sheets/Slides — not byte-downloadable) get `download_url=null` so the key is always present.

## Verification
- 88 drive service tests pass (incl. 11 new: URL shape, native-file skip, missing-id, and per-tool result coverage).
- **Live-verified on a 338 MB video**, without following redirects:
  - `webContentLink` → **HTTP 303** (the bug)
  - `download_url` → **HTTP 206, `content_type=video/mp4`, real bytes** (the mp4 `ftyp` header)

Bumps version to **2.0.8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a non-redirecting Drive download_url for large files to avoid the 303 virus-scan redirect on webContentLink. Also preserve resourceKey in the URL for shared files so direct downloads work reliably.

- **New Features**
  - Added download_url using drive.usercontent.google.com with confirm=t to serve bytes directly without redirects.
  - Applied to share_file, upload_file_content, and search_files results; always present and set to null for native Google files (Docs/Sheets/Slides).
  - Kept webContentLink for backward compatibility; added unit tests and bumped `google-workspace-mcp` to 2.0.8.

- **Bug Fixes**
  - Preserved `resourceKey` in `download_url` for protected shared files; requested `resourceKey` in search, upload, refetch, and share_file fields.

<sup>Written for commit 10ac42d061995af6a4baaafcb4b81957de03f385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Arclio/arclio-mcp-tooling/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

